### PR TITLE
For inputs where the LTR directionality is forced, make that the text…

### DIFF
--- a/uaplus.css
+++ b/uaplus.css
@@ -195,6 +195,9 @@
     :placeholder-shown
   ) {
   direction: ltr;
+
+  /* Align start or left depending on the parent's directionality. */
+  text-align: match-parent;
 }
 
 /**


### PR DESCRIPTION
… alignment follows the parent's directionality

Without this change the alignment can be confusing to RTL readers.

This was inspired by Firefox' codebase in https://searchfox.org/firefox-main/rev/04cf27582307a9c351e991c740828d54cf786b76/browser/components/search/content/addEngine.css#26-30